### PR TITLE
Link prefixing in markdown

### DIFF
--- a/lib/bin/cli.js
+++ b/lib/bin/cli.js
@@ -43,6 +43,8 @@ program.command('build')
   .action((command) => {
     // Set NODE_ENV to 'production'
     process.env.NODE_ENV = 'production'
+    process.env.PREFIX_LINKS = command.prefixLinks && 'prefix-links'
+
 
     const build = require('../utils/build')
     const p = {

--- a/lib/loaders/config-loader/index.js
+++ b/lib/loaders/config-loader/index.js
@@ -1,8 +1,8 @@
 /* @flow weak */
-const toml = require('toml')
-const loaderUtils = require('loader-utils')
-const path = require('path')
-const globPages = require('../../utils/glob-pages')
+import toml from 'toml'
+import loaderUtils from 'loader-utils'
+import path from 'path'
+import globPages from '../../utils/glob-pages'
 
 module.exports = function (source) {
   this.cacheable()

--- a/lib/loaders/markdown-loader/index.js
+++ b/lib/loaders/markdown-loader/index.js
@@ -3,6 +3,8 @@ import frontMatter from 'front-matter'
 import markdownIt from 'markdown-it'
 import hljs from 'highlight.js'
 import objectAssign from 'object-assign'
+import path from 'path'
+import loaderUtils from 'loader-utils'
 
 const highlight = (str, lang) => {
   if ((lang !== null) && hljs.getLanguage(lang)) {
@@ -20,17 +22,28 @@ const highlight = (str, lang) => {
   return ''
 }
 
-const md = markdownIt({
+const md = linkPrefix => markdownIt({
   html: true,
   linkify: true,
   typographer: true,
   highlight,
+  replaceLink: (link) => {
+    if (process.env.PREFIX_LINKS === 'prefix-links' && path.isAbsolute(link)) {
+      return linkPrefix + link
+    }
+    return link
+  },
 })
+  .use(require('markdown-it-replace-link'))
 
 module.exports = function (content) {
   this.cacheable()
+
+  const config = loaderUtils.parseQuery(this.query).config
+  const linkPrefix = config.linkPrefix || ''
+
   const meta = frontMatter(content)
-  const body = md.render(meta.body)
+  const body = md(linkPrefix).render(meta.body)
   const result = objectAssign({}, meta.attributes, {
     body,
   })

--- a/lib/utils/webpack.config.js
+++ b/lib/utils/webpack.config.js
@@ -227,6 +227,9 @@ module.exports = (program, directory, suppliedStage, webpackPort = 1500, routes 
     config.loader('md', {
       test: /\.(md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee)$/,
       loader: 'markdown',
+      query: {
+        config: siteConfig,
+      },
     })
     config.loader('html', {
       test: /\.html$/,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "loader-utils": "^0.2.15",
     "lodash": "^4.15.0",
     "markdown-it": "^7.0.1",
+    "markdown-it-replace-link": "^1.0.1",
     "moment": "^2.14.1",
     "negotiator": "^0.6.1",
     "node-cjsx": "^1.0.0",


### PR DESCRIPTION
This prefix absolute links of a markdown file with the linkPrefix from the config file when the ‘—prefix-link’ option is set up in the command line.